### PR TITLE
fall-protection: prevent spam messages

### DIFF
--- a/1_13/pom.xml
+++ b/1_13/pom.xml
@@ -43,13 +43,6 @@
             <version>7.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
-
-        <dependency>
-            <groupId>com.boydti</groupId>
-            <artifactId>fawe-api</artifactId>
-            <version>latest</version>
-            <scope>provided</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/1_16_FAWE/pom.xml
+++ b/1_16_FAWE/pom.xml
@@ -30,12 +30,12 @@
 
     <artifactId>1_16_FAWE</artifactId>
 
-    <!-- FAWE API -->
     <dependencies>
+        <!-- FAWE API -->
         <dependency>
-            <groupId>com.intellectualsites.fawe</groupId>
-            <artifactId>FAWE-Bukkit</artifactId>
-            <version>1.16-583</version>
+            <groupId>com.fastasyncworldedit</groupId>
+            <artifactId>FastAsyncWorldEdit-Core</artifactId>
+            <version>2.0.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/PlayerListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/PlayerListener.java
@@ -211,13 +211,15 @@ public class PlayerListener implements Listener {
         return false;
     }
 
-    // cancel anvil interact to block the way to rename
-    // missile spawn-egg for changing the spawn
+    // cancel anvil interaction to block renaming, and thus changing missiles
     @EventHandler
     public void onClick(InventoryClickEvent event) {
-        if(event.getInventory().getType() == InventoryType.ANVIL) {
-            if(event.getCurrentItem().getAmount() != 1) {
-                event.setCancelled(true);
+        Game game = getGame(event.getWhoClicked().getLocation());
+        if (game != null) {
+            if (event.getInventory().getType() == InventoryType.ANVIL) {
+                if (event.getCurrentItem().getAmount() != 1) {
+                    event.setCancelled(true);
+                }
             }
         }
     }

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/PlayerListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/PlayerListener.java
@@ -217,9 +217,7 @@ public class PlayerListener implements Listener {
         Game game = getGame(event.getWhoClicked().getLocation());
         if (game != null) {
             if (event.getInventory().getType() == InventoryType.ANVIL) {
-                if (event.getCurrentItem().getAmount() != 1) {
-                    event.setCancelled(true);
-                }
+                event.setCancelled(true);
             }
         }
     }

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/PlayerListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/PlayerListener.java
@@ -41,6 +41,8 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -209,6 +211,16 @@ public class PlayerListener implements Listener {
         return false;
     }
 
+    // cancel anvil interact to block the way to rename
+    // missile spawn-egg for changing the spawn
+    @EventHandler
+    public void onClick(InventoryClickEvent event) {
+        if(event.getInventory().getType() == InventoryType.ANVIL) {
+            if(event.getCurrentItem().getAmount() != 1) {
+                event.setCancelled(true);
+            }
+        }
+    }
 
     // Internal stuff
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/stats/GameProfileBuilder.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/stats/GameProfileBuilder.java
@@ -21,16 +21,10 @@ package de.butzlabben.missilewars.util.stats;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParseException;
 import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
-import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.properties.Property;
-import com.mojang.authlib.properties.PropertyMap;
-import com.mojang.util.UUIDTypeAdapter;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -44,6 +38,7 @@ import java.util.Map;
 import java.util.UUID;
 import lombok.Getter;
 import org.yaml.snakeyaml.external.biz.base64Coder.Base64Coder;
+import com.mojang.util.UUIDTypeAdapter;
 
 /**
  * @author Butzlabben

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/wrapper/game/RespawnGoldBlock.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/wrapper/game/RespawnGoldBlock.java
@@ -59,14 +59,15 @@ public class RespawnGoldBlock implements Listener {
     }
 
     private void activate() {
+        double seconds = (double) duration / 20;
+        if ((seconds == Math.floor(seconds)) && !Double.isInfinite(seconds)) {
+            player.sendMessage(MessageConfig.getMessage("fall_protection").replace("%seconds%", "" + (int) seconds));
+        }
+
         task = Bukkit.getScheduler().scheduleSyncRepeatingTask(MissileWars.getInstance(), () -> {
             if (duration == 0) {
                 stop();
                 return;
-            }
-            double seconds = (double) duration / 20;
-            if ((seconds == Math.floor(seconds)) && !Double.isInfinite(seconds)) {
-                player.sendMessage(MessageConfig.getMessage("fall_protection").replace("%seconds%", "" + (int) seconds));
             }
             if (player.getGameMode() != GameMode.SURVIVAL) {
                 stop();

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,11 @@
          xmlns="http://maven.apache.org/POM/4.0.0"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
 
     <groupId>de.butzlabben</groupId>
     <artifactId>missilewars</artifactId>
@@ -42,77 +47,79 @@
         </repository>
 
         <repository>
-            <id>we-repo</id>
-            <url>http://maven.sk89q.com/repo/</url>
+            <id>enginehub-maven</id>
+            <url>https://maven.enginehub.org/repo/</url>
         </repository>
 
         <repository>
-            <id>CodeMC</id>
-            <url>https://repo.codemc.org/repository/maven-public</url>
+            <id>jitpack.io</id>
+            <url>https://jitpack.io</url>
         </repository>
 
         <repository>
-            <id>vault-repo</id>
-            <url>http://nexus.hc.to/content/repositories/pub_releases</url>
-        </repository>
-
-        <!--Repo for CommandFramework-->
-        <repository>
-            <id>pp-public</id>
-            <url>http://nexus.myplayplanet.net/repository/public/</url>
-        </repository>
-        <repository>
-            <id>fawe-repo</id>
-            <url>http://ci.athion.net/job/FastAsyncWorldEdit/ws/mvn/</url>
+            <id>S01-Sonatype-Snapshots</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
 
         <repository>
-            <id>mojang</id>
-            <name>Mojang's Repository</name>
+            <id>minecraft-repo</id>
             <url>https://libraries.minecraft.net/</url>
         </repository>
 
-        <!-- FAWE 1.16-->
-        <repository>
-            <id>IntellectualSites</id>
-            <url>https://mvn.intellectualsites.com/content/repositories/releases/</url>
-        </repository>
     </repositories>
 
     <dependencies>
+        <!-- repo spigot-repo -->
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.14-R0.1-SNAPSHOT</version>
+            <version>1.18.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
+        <!-- repo enginehub-maven -->
         <dependency>
-            <groupId>org.bukkit</groupId>
-            <artifactId>bukkit</artifactId>
-            <version>1.14-R0.1-SNAPSHOT</version>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-bukkit</artifactId>
+            <version>7.2.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.sk89q.worldedit</groupId>
+            <artifactId>worldedit-core</artifactId>
+            <version>7.2.0-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
+        <!-- repo jitpack.io -->
         <dependency>
-            <groupId>net.milkbowl.vault</groupId>
+            <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
-            <version>1.6</version>
+            <version>1.7</version>
             <scope>provided</scope>
         </dependency>
 
+        <!-- repo maven central -->
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.20</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
 
+        <!-- repo minecraft-repo -->
         <dependency>
             <groupId>com.mojang</groupId>
             <artifactId>authlib</artifactId>
             <version>1.5.21</version>
             <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.bstats</groupId>
+            <artifactId>bstats-bukkit</artifactId>
+            <version>2.2.1</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Currently, the player get a message with ever seconds about the fall-protection time, after death. This may be too much, so I suggest, to send the message only with the start of fall-protection. The second message is still the info about the end of it. This is enough, I think.