### PR TITLE
Adding PAPI Placeholders about MissileWars

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 MissileWars is a famous, fun and fast minigame spigot-plugin for Minecraft
 
 ## Downloads
-You can download the jars in the "[Releases](https://github.com/Butzlabben/missilewars/releases)" section on GitHub or build them yourself via `mvnw install`.
+You can download the jars in the "[Releases](https://github.com/Butzlabben/missilewars/releases)" 
+section on GitHub or build them yourself via `mvnw install`.
 
-However, if you [buy the resource](https://www.spigotmc.org/resources/62947/
-) and leave a review, you will also receive an extra map and some more missiles.
+However, if you [buy the resource](https://www.spigotmc.org/resources/62947) and leave a review, 
+you will also receive an extra map and some more missiles.
 
 ## Contributions
-- Contributions are always welcome, just fork this project, make your changes and create a pull request.
+Contributions are always welcome, just fork this project, make your changes and create a pull request.
+
+## Documentation
+All information about the Commands, Permissions, Placeholders and the Configuration can be found 
+in our [Github Wiki](https://github.com/Butzlabben/missilewars/wiki).
 
 ## Donate
 [![Donation link](https://www.paypalobjects.com/en_US/DK/i/btn/btn_donateCC_LG.gif)](https://www.paypal.com/cgi-bin/webscr?cmd=_donations&business=naegele_daniel%40web.de&currency_code=EUR&source=url)

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/MissileWars.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/MissileWars.java
@@ -28,6 +28,7 @@ import de.butzlabben.missilewars.listener.PlayerListener;
 import de.butzlabben.missilewars.listener.signs.ClickListener;
 import de.butzlabben.missilewars.listener.signs.ManageListener;
 import de.butzlabben.missilewars.util.ConnectionHolder;
+import de.butzlabben.missilewars.util.MissileWarsPlaceholder;
 import de.butzlabben.missilewars.util.MoneyUtil;
 import de.butzlabben.missilewars.util.SetupUtil;
 import de.butzlabben.missilewars.util.stats.PreFetcher;
@@ -118,6 +119,11 @@ public class MissileWars extends JavaPlugin {
 
         if (Config.isPrefetchPlayers()) {
             PreFetcher.preFetchPlayers(new StatsFetcher(new Date(0L), ""));
+        }
+
+        // Small check to make sure that PlaceholderAPI is installed
+        if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new MissileWarsPlaceholder(this).register();
         }
 
         endTime = System.currentTimeMillis();

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/MissileWars.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/MissileWars.java
@@ -122,8 +122,9 @@ public class MissileWars extends JavaPlugin {
         }
 
         // Small check to make sure that PlaceholderAPI is installed
-        if(Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
             new MissileWarsPlaceholder(this).register();
+            Logger.NORMAL.log("The PlaceholderAPI is installed. New placeholders are provided by MissileWars.");
         }
 
         endTime = System.currentTimeMillis();

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/MissileWarsPlaceholder.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/MissileWarsPlaceholder.java
@@ -1,0 +1,101 @@
+/*
+ * This file is part of MissileWars (https://github.com/Butzlabben/missilewars).
+ * Copyright (c) 2018-2021 Daniel Nägele.
+ *
+ * MissileWars is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MissileWars is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MissileWars.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.butzlabben.missilewars.util;
+
+import de.butzlabben.missilewars.MissileWars;
+import de.butzlabben.missilewars.game.Game;
+import de.butzlabben.missilewars.game.GameManager;
+import de.butzlabben.missilewars.wrapper.abstracts.Arena;
+import de.butzlabben.missilewars.wrapper.abstracts.Lobby;
+import me.clip.placeholderapi.expansion.PlaceholderExpansion;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+
+public class MissileWarsPlaceholder extends PlaceholderExpansion {
+
+    private final MissileWars plugin;
+
+    public MissileWarsPlaceholder(MissileWars plugin) {
+        this.plugin = plugin;
+    }
+
+    @Override
+    public String getAuthor() {
+        return "Daniel Nägele";
+    }
+
+    @Override
+    public String getIdentifier() {
+        return "missilewars";
+    }
+
+    @Override
+    public String getVersion() {
+        return "0.0.1";
+    }
+
+    // This is required or else PlaceholderAPI will unregister the Expansion on reload
+    @Override
+    public boolean persist() {
+        return true;
+    }
+
+    @Override
+    public String onRequest(OfflinePlayer offlinePlayer, String params) {
+
+        if (params.endsWith("_this")) {
+            if (!offlinePlayer.isOnline()) return "ERROR: No a player!";
+
+            Player player = offlinePlayer.getPlayer();
+            Game playerGame = GameManager.getInstance().getGame(player.getLocation());
+            if (playerGame == null) return "ERROR: Wrong world!";
+
+            if (params.startsWith("lobby_")) params.replace("_this", playerGame.getLobby().getName());
+            if (params.startsWith("arena_")) params.replace("_this", playerGame.getArena().getName());
+        }
+
+
+        for (Game game : GameManager.getInstance().getGames().values()) {
+            Lobby lobby = game.getLobby();
+
+            for (Arena arena : lobby.getArenas()) {
+
+                // %missilewars_lobby_displayname_<lobby name or 'this'>%
+                if (params.equalsIgnoreCase("lobby_displayname_" + lobby.getName())){
+                    return lobby.getDisplayName();
+                }
+
+                // %missilewars_arena_displayname_<arena name or 'this'>%
+                if (params.equalsIgnoreCase("arena_displayname_" + arena.getName())) {
+                    return arena.getDisplayName();
+                }
+
+                // %missilewars_arena_missileamount_<arena name or 'this'>%
+                if (params.equalsIgnoreCase("arena_missileamount_" + arena.getName())) {
+                    return Integer.toString(arena.getMissileConfiguration().getMissiles().size());
+                }
+
+            }
+        }
+
+        // Placeholder is unknown by the Expansion
+        return null;
+    }
+
+}

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/MissileWarsPlaceholder.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/MissileWarsPlaceholder.java
@@ -60,11 +60,15 @@ public class MissileWarsPlaceholder extends PlaceholderExpansion {
     public String onRequest(OfflinePlayer offlinePlayer, String params) {
 
         if (params.endsWith("_this")) {
-            if (!offlinePlayer.isOnline()) return "ERROR: No a player!";
+            if (!offlinePlayer.isOnline()) return "§c§oPlayer is not online!";
 
             Player player = offlinePlayer.getPlayer();
             Game playerGame = GameManager.getInstance().getGame(player.getLocation());
-            if (playerGame == null) return "ERROR: Wrong world!";
+
+            if (playerGame == null) {
+                if (params.startsWith("lobby_")) return "§c§oThis is not a lobby area!";
+                if (params.startsWith("arena_")) return "§c§oThis is not a game arena!";
+            }
 
             if (params.startsWith("lobby_")) params.replace("_this", playerGame.getLobby().getName());
             if (params.startsWith("arena_")) params.replace("_this", playerGame.getArena().getName());
@@ -77,7 +81,7 @@ public class MissileWarsPlaceholder extends PlaceholderExpansion {
             for (Arena arena : lobby.getArenas()) {
 
                 // %missilewars_lobby_displayname_<lobby name or 'this'>%
-                if (params.equalsIgnoreCase("lobby_displayname_" + lobby.getName())){
+                if (params.equalsIgnoreCase("lobby_displayname_" + lobby.getName())) {
                     return lobby.getDisplayName();
                 }
 

--- a/missilewars-plugin/src/main/resources-filtered/plugin.yml
+++ b/missilewars-plugin/src/main/resources-filtered/plugin.yml
@@ -4,7 +4,7 @@ version: ${project.version}
 main: de.butzlabben.missilewars.MissileWars
 api-version: 1.13
 depend: [ WorldEdit ]
-softdepend: [ Vault, FastAsyncWorldEdit ]
+softdepend: [ Vault, FastAsyncWorldEdit, PlaceholderAPI ]
 
 permissions:
   mw.*:

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,10 @@
             <url>https://libraries.minecraft.net/</url>
         </repository>
 
+        <repository>
+            <id>placeholderapi</id>
+            <url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -120,6 +124,14 @@
             <groupId>com.mojang</groupId>
             <artifactId>authlib</artifactId>
             <version>1.5.21</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- repo placeholderapi -->
+        <dependency>
+            <groupId>me.clip</groupId>
+            <artifactId>placeholderapi</artifactId>
+            <version>2.11.2</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
New placeholders for plugins with PlaceholderAPI support:
- `%missilewars_lobby_displayname_<lobby name or 'this'>%`
- `%missilewars_arena_displayname_<arena name or 'this'>%`
- `%missilewars_arena_missileamount_<arena name or 'this'>%`