### PR TITLE
Fixing/misc

### DIFF
--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
@@ -789,7 +789,7 @@ public class Game {
 
         if (maxSize == -1) return false;
 
-        int currentSize = players.size();
+        int currentSize = players.size() - (team1.getMembers().size() + team2.getMembers().size());
         return currentSize >= maxSize;
     }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
@@ -488,9 +488,9 @@ public class Game {
     }
 
     public void broadcast(String message) {
-        for (MWPlayer player : players.values()) {
-            Player p = player.getPlayer();
-            if (p != null && p.isOnline()) p.sendMessage(message);
+        for (MWPlayer mwPlayer : players.values()) {
+            Player player = mwPlayer.getPlayer();
+            if (player != null && player.isOnline()) player.sendMessage(message);
         }
     }
 
@@ -704,21 +704,21 @@ public class Game {
     public void sendGameResult() {
 
         for (Player player : gameWorld.getWorld().getPlayers()) {
-            MWPlayer missileWarsPlayer = getPlayer(player);
+            MWPlayer mwPlayer = getPlayer(player);
 
             // team member of team 1
-            if (team1.isMember(missileWarsPlayer)) {
-                team1.sendMoney(missileWarsPlayer);
-                team1.sendGameResultTitle(missileWarsPlayer);
-                team1.sendGameResultSound(missileWarsPlayer);
+            if (team1.isMember(mwPlayer)) {
+                team1.sendMoney(mwPlayer);
+                team1.sendGameResultTitle(mwPlayer);
+                team1.sendGameResultSound(mwPlayer);
                 continue;
             }
 
             // team member of team 2
-            if (team2.isMember(missileWarsPlayer)) {
-                team2.sendMoney(missileWarsPlayer);
-                team2.sendGameResultTitle(missileWarsPlayer);
-                team2.sendGameResultSound(missileWarsPlayer);
+            if (team2.isMember(mwPlayer)) {
+                team2.sendMoney(mwPlayer);
+                team2.sendGameResultTitle(mwPlayer);
+                team2.sendGameResultSound(mwPlayer);
                 continue;
             }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
@@ -121,12 +121,12 @@ public class Game {
         }
 
         if (lobby.getPossibleArenas().size() == 0) {
-            Logger.ERROR.log(("At least one valid arena must be set at lobby " + lobby.getName()));
+            Logger.ERROR.log("At least one valid arena must be set at lobby " + lobby.getName());
             return;
         }
 
         if (lobby.getPossibleArenas().stream().noneMatch(a -> Arenas.getFromName(a).isPresent())) {
-            Logger.ERROR.log(("None of the specified arenas match a real arena for the lobby " + lobby.getName()));
+            Logger.ERROR.log("None of the specified arenas match a real arena for the lobby " + lobby.getName());
             return;
         }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
@@ -292,11 +292,11 @@ public class Game {
     }
 
     public void disableGameOnServerStop() {
-
-        for (MWPlayer player : players.values()) {
-            playerLeaveFromGame(player);
+        
+        for (MWPlayer mwPlayer : players.values()) {
+            teleportToFallbackSpawn(mwPlayer.getPlayer());
         }
-
+        
         gameWorld.unload();
     }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
@@ -497,7 +497,7 @@ public class Game {
     public void startForPlayer(Player player) {
         MWPlayer mwPlayer = getPlayer(player);
         if (mwPlayer == null) {
-            System.err.println("[MissileWars] Error starting game at player " + player.getName());
+            Logger.ERROR.log("Error starting game at player " + player.getName());
             return;
         }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/GameWorld.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/GameWorld.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 import lombok.ToString;
 import org.apache.commons.io.FileUtils;
 import org.bukkit.Bukkit;
+import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.WorldCreator;
 import org.bukkit.entity.Entity;
@@ -134,8 +135,9 @@ public class GameWorld {
             Logger.DEBUG.log("Loading new gameworld");
             World world = Bukkit.createWorld(new WorldCreator(worldName));
             Bukkit.getWorlds().add(world);
-            world.setGameRuleValue("doTileDrops", String.valueOf(game.getArena().isDoTileDrops()));
-            world.setGameRuleValue("keepInventory", String.valueOf(game.getArena().isKeepInventory()));
+            
+            world.setGameRule(GameRule.DO_TILE_DROPS, game.getArena().isDoTileDrops());
+            world.setGameRule(GameRule.KEEP_INVENTORY, game.getArena().isKeepInventory());
         }
     }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Team.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Team.java
@@ -67,37 +67,37 @@ public class Team {
         return game.getTeam1();
     }
 
-    public void removeMember(MWPlayer player) {
-        if (!isMember(player)) return;
+    public void removeMember(MWPlayer mwPlayer) {
+        if (!isMember(mwPlayer)) return;
 
-        Player p = player.getPlayer();
-        player.setTeam(null);
+        Player player = mwPlayer.getPlayer();
+        mwPlayer.setTeam(null);
 
-        if (p != null) {
-            p.setDisplayName("§7" + p.getName() + "§r");
+        if (player != null) {
+            player.setDisplayName("§7" + player.getName() + "§r");
         }
 
-        members.removeIf(mp -> mp.getUuid().equals(player.getUuid()));
+        members.removeIf(mp -> mp.getUuid().equals(mwPlayer.getUuid()));
     }
 
-    public void addMember(MWPlayer player) {
-        if (isMember(player)) return;
+    public void addMember(MWPlayer mwPlayer) {
+        if (isMember(mwPlayer)) return;
 
         // Already in a team?
-        if (player.getTeam() != null) {
-            player.getTeam().removeMember(player);
+        if (mwPlayer.getTeam() != null) {
+            mwPlayer.getTeam().removeMember(mwPlayer);
         }
 
-        Player p = player.getPlayer();
-        if (p == null) {
-            Logger.WARN.log("Could not add player " + player.getUuid().toString() + " to a team because he went offline");
+        Player player = mwPlayer.getPlayer();
+        if (player == null) {
+            Logger.WARN.log("Could not add player " + mwPlayer.getUuid().toString() + " to a team because he went offline");
             return;
         }
 
-        members.add(player);
-        player.setTeam(this);
-        p.setDisplayName(getColorCode() + p.getName() + "§r");
-        p.getInventory().setArmorContents(getTeamArmor());
+        members.add(mwPlayer);
+        mwPlayer.setTeam(this);
+        player.setDisplayName(getColorCode() + player.getName() + "§r");
+        player.getInventory().setArmorContents(getTeamArmor());
     }
 
     public String getFullname() {
@@ -147,15 +147,15 @@ public class Team {
         return this.teamArmor;
     }
 
-    public boolean isMember(MWPlayer player) {
-        return members.contains(player);
+    public boolean isMember(MWPlayer mwPlayer) {
+        return members.contains(mwPlayer);
     }
 
     /**
      * This method sends all team members the money for playing the game
      * with a specific amount for win and lose.
      */
-    public void sendMoney(MWPlayer missileWarsPlayer) {
+    public void sendMoney(MWPlayer mwPlayer) {
         int money;
 
         switch (gameResult) {
@@ -173,14 +173,14 @@ public class Team {
                 break;
         }
 
-        MoneyUtil.giveMoney(missileWarsPlayer.getUuid(), money);
+        MoneyUtil.giveMoney(mwPlayer.getUuid(), money);
     }
 
     /**
      * This method sends all team members the title / subtitle of the
      * game result.
      */
-    public void sendGameResultTitle(MWPlayer missileWarsPlayer) {
+    public void sendGameResultTitle(MWPlayer mwPlayer) {
         String title;
         String subTitle;
 
@@ -203,22 +203,22 @@ public class Team {
                 break;
         }
 
-        VersionUtil.sendTitle(missileWarsPlayer.getPlayer(), title, subTitle);
+        VersionUtil.sendTitle(mwPlayer.getPlayer(), title, subTitle);
     }
 
     /**
      * This method sends all team members the end-sound of the
      * game result.
      */
-    public void sendGameResultSound(MWPlayer missileWarsPlayer) {
+    public void sendGameResultSound(MWPlayer mwPlayer) {
 
         switch (gameResult) {
             case WIN:
-                VersionUtil.playPling(missileWarsPlayer.getPlayer());
+                VersionUtil.playPling(mwPlayer.getPlayer());
                 break;
             case LOSE:
             case DRAW:
-                VersionUtil.playDraw(missileWarsPlayer.getPlayer());
+                VersionUtil.playDraw(mwPlayer.getPlayer());
                 break;
             default:
                 break;

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/RespawnGoldBlock.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/RespawnGoldBlock.java
@@ -145,8 +145,8 @@ public class RespawnGoldBlock implements Listener {
 
     @EventHandler
     public void onSneak(PlayerToggleSneakEvent e) {
-        Player p = e.getPlayer();
-        if (p == player && (map.size() != 0) && (p.isSneaking())) {
+        Player eventPlayer = e.getPlayer();
+        if (eventPlayer == player && (map.size() != 0) && (eventPlayer.isSneaking())) {
             for (Location loc : map.keySet()) {
                 loc.getBlock().setType(map.get(loc).getKey());
                 BlockSetterProvider.getBlockDataSetter().setData(loc.getBlock(), map.get(loc).getValue());
@@ -154,7 +154,7 @@ public class RespawnGoldBlock implements Listener {
             map.clear();
             Bukkit.getScheduler().cancelTask(task);
             HandlerList.unregisterAll(this);
-            p.sendMessage(Messages.getMessage("fall_protection_deactivated"));
+            eventPlayer.sendMessage(Messages.getMessage("fall_protection_deactivated"));
         }
     }
 }

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/ScoreboardManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/ScoreboardManager.java
@@ -142,14 +142,14 @@ public class ScoreboardManager {
                 int playerCounter = 0;
 
                 // list all team members
-                for (MWPlayer player : placeholderTeam.getMembers()) {
+                for (MWPlayer mwPlayer : placeholderTeam.getMembers()) {
 
                     // limit check
                     if (playerCounter >= MEMBER_LIST_MAX_SIZE) {
                         break;
                     }
 
-                    String playerName = player.getPlayer().getName();
+                    String playerName = mwPlayer.getPlayer().getName();
                     String teamColor = placeholderTeam.getColor();
 
                     replacedLine = MEMBER_LIST_STYLE.replace("%playername%", playerName)

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/stats/FightStats.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/stats/FightStats.java
@@ -103,14 +103,14 @@ public class FightStats {
 
             if (fightID == -1)
                 return;
-            for (MWPlayer player : players) {
-                if (player.getTeam() != null) {
+            for (MWPlayer mwPlayer : players) {
+                if (mwPlayer.getTeam() != null) {
                     PreparedStatement statement = ConnectionHolder.prepareStatement("INSERT INTO " + Config.getFightMembersTable() + " (fid, player, team) VALUES "
                             + " (?, ?, ?)");
                     statement.setInt(1, fightID);
-                    statement.setString(2, player.getUuid().toString());
+                    statement.setString(2, mwPlayer.getUuid().toString());
 
-                    if (player.getTeam() == game.getTeam1())
+                    if (mwPlayer.getTeam() == game.getTeam1())
                         statement.setInt(3, 1);
                     else
                         statement.setInt(3, 2);

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/timer/LobbyTimer.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/timer/LobbyTimer.java
@@ -49,9 +49,9 @@ public class LobbyTimer extends Timer implements Runnable {
     public void tick() {
         if (getGame().getPlayers().size() == 0) return;
 
-        for (MWPlayer mp : getGame().getPlayers().values()) {
-            if (mp.getPlayer() == null) continue;
-            mp.getPlayer().setLevel(seconds);
+        for (MWPlayer mwPlayer : getGame().getPlayers().values()) {
+            if (mwPlayer.getPlayer() == null) continue;
+            mwPlayer.getPlayer().setLevel(seconds);
         }
 
         int size1 = getGame().getTeam1().getMembers().size();
@@ -108,8 +108,8 @@ public class LobbyTimer extends Timer implements Runnable {
     }
 
     private void playPling() {
-        for (MWPlayer p : getGame().getPlayers().values()) {
-            VersionUtil.playPling(p.getPlayer());
+        for (MWPlayer mwPlayer : getGame().getPlayers().values()) {
+            VersionUtil.playPling(mwPlayer.getPlayer());
         }
     }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/inventory/OrcInventory.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/inventory/OrcInventory.java
@@ -18,14 +18,16 @@
 
 package de.butzlabben.missilewars.inventory;
 
-import java.util.HashMap;
-import java.util.Map.Entry;
-import java.util.Objects;
+import de.butzlabben.missilewars.Logger;
 import lombok.Getter;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
+
+import java.util.HashMap;
+import java.util.Map.Entry;
+import java.util.Objects;
 
 @Getter
 public abstract class OrcInventory {
@@ -112,7 +114,7 @@ public abstract class OrcInventory {
             if (entry.getKey() >= 0 && entry.getKey() < size) {
                 inv.setItem(entry.getKey(), entry.getValue().getItemStack(p));
             } else {
-                System.err.println("There is a problem with a configured Item!");
+                Logger.ERROR.log("There is a problem with a configured Item!");
             }
         }
 
@@ -136,7 +138,7 @@ public abstract class OrcInventory {
             if (entry.getKey() >= 0 && entry.getKey() < size) {
                 inv.setItem(entry.getKey(), entry.getValue().getItemStack());
             } else {
-                System.err.println("There is a problem with a configured Item!");
+                Logger.ERROR.log("There is a problem with a configured Item!");
             }
         }
         return inv;

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/inventory/pages/InventoryPage.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/inventory/pages/InventoryPage.java
@@ -18,6 +18,7 @@
 
 package de.butzlabben.missilewars.inventory.pages;
 
+import de.butzlabben.missilewars.Logger;
 import de.butzlabben.missilewars.inventory.OrcInventory;
 import de.butzlabben.missilewars.inventory.OrcItem;
 import de.butzlabben.missilewars.util.version.VersionUtil;
@@ -62,7 +63,7 @@ public class InventoryPage extends OrcInventory {
 
     public void addItem(OrcItem item) {
         if (i > 36) {
-            System.err.println("More items than allowed in page view");
+            Logger.ERROR.log("More items than allowed in page view");
             return;
         }
         addItem(i, item);

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/PlayerListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/PlayerListener.java
@@ -98,7 +98,6 @@ public class PlayerListener implements Listener {
         if (game == null) return;
 
         Player player = event.getPlayer();
-        
         game.teleportToFallbackSpawn(player);
     }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/PlayerListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/PlayerListener.java
@@ -98,10 +98,7 @@ public class PlayerListener implements Listener {
         if (game == null) return;
 
         Player player = event.getPlayer();
-
-        // old game handling:
-        registerPlayerArenaLeaveEvent(player, game);
-
+        
         game.teleportToFallbackSpawn(player);
     }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/ConnectionHolder.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/ConnectionHolder.java
@@ -63,7 +63,7 @@ public class ConnectionHolder {
         synchronized (lock) {
             try {
                 if (connection == null || connection.isClosed()) {
-                    System.err.println("[MySQL] Connection does not exist or was already closed");
+                    Logger.ERROR.log("[MySQL] Connection does not exist or was already closed");
                     return;
                 }
                 connection.close();

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/SetupUtil.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/SetupUtil.java
@@ -147,7 +147,7 @@ public class SetupUtil {
                 InputStream in = MissileWars.getInstance().getResource(resource);
                 Files.copy(in, file.toPath());
             } catch (IOException e) {
-                System.err.println("Wasn't able to create Config");
+                Logger.ERROR.log("Wasn't able to create Config");
                 e.printStackTrace();
             }
         }


### PR DESCRIPTION
- Fix teleporting players to fallback spawn with server stop
- Fix twice calling of arena leave event (because of teleport)
- Fix #56 with using of newer methods to set the world gamerule - should work from 1.13.x - 1.19.x (The arena config option `keep_inventory` will change the `keepInventory` gamerule too.)
- Fix `max_spectators` calculation
- Fix warn `Nag author(s): '[Butzlabben]' of 'MissileWars' about their usage of System.out/err.print. Please use your plugin's logger instead (JavaPlugin#getLogger).`