### PR TITLE
Refactoring, Unified config options for folders

### DIFF
--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/MissileWars.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/MissileWars.java
@@ -125,13 +125,9 @@ public class MissileWars extends JavaPlugin {
         if (Config.isPrefetchPlayers()) {
             PreFetcher.preFetchPlayers(new StatsFetcher(new Date(0L), ""));
         }
-
-        // Small check to make sure that PlaceholderAPI is installed
-        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
-            new MissileWarsPlaceholder(this).register();
-            Logger.NORMAL.log("The PlaceholderAPI is installed. New placeholders are provided by MissileWars.");
-        }
-
+        
+        checkPlaceholderAPI();
+        
         endTime = System.currentTimeMillis();
         Logger.SUCCESS.log("MissileWars was enabled in " + (endTime - startTime) + "ms");
     }
@@ -143,7 +139,18 @@ public class MissileWars extends JavaPlugin {
 
         ConnectionHolder.close();
     }
-
+    
+    /**
+     * This method checks if the PlaceholderAPI is installed. When it is 
+     * installed, a message is sent to the log.
+     */
+    private void checkPlaceholderAPI() {
+        if (Bukkit.getPluginManager().getPlugin("PlaceholderAPI") != null) {
+            new MissileWarsPlaceholder(this).register();
+            Logger.NORMAL.log("The PlaceholderAPI is installed. New placeholders are provided by MissileWars.");
+        }
+    }
+    
     /**
      * This method registers all events of the missilewars event listener.
      */

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/Config.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/Config.java
@@ -203,7 +203,7 @@ public class Config {
     }
 
     public static String getArenasFolder() {
-        return cfg.getString("arenas.folder") + "/";
+        return cfg.getString("arenas.folder");
     }
 
     public static boolean isMultipleLobbies() {
@@ -211,7 +211,7 @@ public class Config {
     }
 
     public static String getLobbiesFolder() {
-        return cfg.getString("lobbies.folder") + "/";
+        return cfg.getString("lobbies.folder");
     }
 
     public static String getDefaultLobby() {
@@ -219,7 +219,7 @@ public class Config {
     }
 
     public static String getMissilesFolder() {
-        return cfg.getString("missiles.folder") + "/";
+        return cfg.getString("missiles.folder");
     }
 
     public static int getReplaceTicks() {

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/Config.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/Config.java
@@ -78,11 +78,13 @@ public class Config {
 
         cfg.addDefault("restart_after_fights", 10);
 
-        cfg.addDefault("arena_folder", "plugins/MissileWars/arenas");
+        cfg.addDefault("arenas.folder", "plugins/MissileWars/arenas");
 
         cfg.addDefault("lobbies.multiple_lobbies", false);
         cfg.addDefault("lobbies.folder", "plugins/MissileWars/lobbies");
         cfg.addDefault("lobbies.default_lobby", "lobby0.yml");
+
+        cfg.addDefault("missiles.folder", "plugins/MissileWars/missiles");
 
         cfg.addDefault("replace.material", JUKEBOX.name());
         cfg.addDefault("replace.after_ticks", 2);
@@ -200,8 +202,8 @@ public class Config {
         return cfg.getInt("restart_after_fights");
     }
 
-    public static String getArenaFolder() {
-        return cfg.getString("arena_folder") + "/";
+    public static String getArenasFolder() {
+        return cfg.getString("arenas.folder") + "/";
     }
 
     public static boolean isMultipleLobbies() {
@@ -214,6 +216,10 @@ public class Config {
 
     public static String getDefaultLobby() {
         return cfg.getString("lobbies.default_lobby");
+    }
+
+    public static String getMissilesFolder() {
+        return cfg.getString("missiles.folder") + "/";
     }
 
     public static int getReplaceTicks() {

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Arenas.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Arenas.java
@@ -40,7 +40,7 @@ public class Arenas {
     public static void load() {
         arenas.clear();
 
-        File folder = new File(Config.getArenaFolder());
+        File folder = new File(Config.getArenasFolder());
 
         // Creates the folder "/arena", if not existing
         folder.mkdirs();

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/GameManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/GameManager.java
@@ -59,7 +59,8 @@ public class GameManager {
         if (Config.isMultipleLobbies()) {
             lobbyFiles = new File(Config.getLobbiesFolder()).listFiles();
         } else {
-            File file = new File(Config.getLobbiesFolder() + Config.getDefaultLobby());
+            File lobbiesFolder = new File(Config.getLobbiesFolder());
+            File file = new File(lobbiesFolder, Config.getDefaultLobby());
             if (file.exists()) {
                 lobbyFiles = new File[]{file};
             }
@@ -68,7 +69,8 @@ public class GameManager {
 
         if (lobbyFiles.length == 0) {
             Logger.WARN.log("No lobby configs found. Creating default one");
-            File file = new File(Config.getLobbiesFolder() + Config.getDefaultLobby());
+            File lobbiesFolder = new File(Config.getLobbiesFolder());
+            File file = new File(lobbiesFolder, Config.getDefaultLobby());
             try {
                 file.createNewFile();
                 Serializer.serialize(file, new Lobby());

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/GameManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/GameManager.java
@@ -59,7 +59,7 @@ public class GameManager {
         if (Config.isMultipleLobbies()) {
             lobbyFiles = new File(Config.getLobbiesFolder()).listFiles();
         } else {
-            File file = new File(Config.getLobbiesFolder() + "/" + Config.getDefaultLobby());
+            File file = new File(Config.getLobbiesFolder() + Config.getDefaultLobby());
             if (file.exists()) {
                 lobbyFiles = new File[]{file};
             }
@@ -68,7 +68,7 @@ public class GameManager {
 
         if (lobbyFiles.length == 0) {
             Logger.WARN.log("No lobby configs found. Creating default one");
-            File file = new File(Config.getLobbiesFolder() + "/" + Config.getDefaultLobby());
+            File file = new File(Config.getLobbiesFolder() + Config.getDefaultLobby());
             try {
                 file.createNewFile();
                 Serializer.serialize(file, new Lobby());

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/GameWorld.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/GameWorld.java
@@ -121,7 +121,7 @@ public class GameWorld {
                 i++;
             } while (file.exists() || file.isDirectory());
 
-            File newFile = new File(Config.getArenaFolder() + "/" + templateName);
+            File newFile = new File(Config.getArenasFolder() + templateName);
 
             try {
                 FileUtils.copyDirectory(newFile, file);

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/GameWorld.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/GameWorld.java
@@ -121,7 +121,8 @@ public class GameWorld {
                 i++;
             } while (file.exists() || file.isDirectory());
 
-            File newFile = new File(Config.getArenasFolder() + templateName);
+            File arenasFolder = new File(Config.getArenasFolder());
+            File newFile = new File(arenasFolder, templateName);
 
             try {
                 FileUtils.copyDirectory(newFile, file);

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/MotdManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/MotdManager.java
@@ -19,6 +19,7 @@
 package de.butzlabben.missilewars.game.misc;
 
 import de.butzlabben.missilewars.configuration.Config;
+import de.butzlabben.missilewars.configuration.Messages;
 import de.butzlabben.missilewars.game.Game;
 import de.butzlabben.missilewars.game.enums.GameState;
 import org.bukkit.ChatColor;
@@ -53,9 +54,12 @@ public class MotdManager {
                     break;
             }
 
-            String players = "" + game.getPlayers().values().size();
-            String maxPlayers = "" + game.getLobby().getMaxSize();
-            motd = ChatColor.translateAlternateColorCodes('&', newMotd).replace("%max_players%", maxPlayers).replace("%players%", players);
+            int players = game.getPlayers().values().size();
+            int maxPlayers = game.getLobby().getMaxSize();
+            motd = ChatColor.translateAlternateColorCodes('&', newMotd)
+                    .replace("%max_players%", "" + maxPlayers)
+                    .replace("%players%", "" + players)
+                    .replace("%prefix%", Messages.getPrefix());
         }
     }
 }

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/missile/Missile.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/missile/Missile.java
@@ -84,7 +84,8 @@ public class Missile {
     }
 
     public File getSchematic() {
-        File file = new File(Config.getMissilesFolder() + getSchematicName(false));
+        File missilesFolder = new File(Config.getMissilesFolder());
+        File file = new File(missilesFolder, getSchematicName(false));
         return file;
     }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/missile/Missile.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/missile/Missile.java
@@ -20,7 +20,7 @@ package de.butzlabben.missilewars.game.missile;
 
 import com.google.gson.annotations.SerializedName;
 import de.butzlabben.missilewars.Logger;
-import de.butzlabben.missilewars.MissileWars;
+import de.butzlabben.missilewars.configuration.Config;
 import de.butzlabben.missilewars.game.Game;
 import de.butzlabben.missilewars.game.missile.paste.PasteProvider;
 import de.butzlabben.missilewars.util.version.VersionUtil;
@@ -84,8 +84,7 @@ public class Missile {
     }
 
     public File getSchematic() {
-        File pluginDir = MissileWars.getInstance().getDataFolder();
-        File file = new File(pluginDir, "missiles/" + getSchematicName(false));
+        File file = new File(Config.getMissilesFolder() + getSchematicName(false));
         return file;
     }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/SetupUtil.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/SetupUtil.java
@@ -108,7 +108,8 @@ public class SetupUtil {
     }
 
     public static void checkMap(String worldName) {
-        File file = new File(Config.getArenasFolder() + worldName);
+        File arenasFolder = new File(Config.getArenasFolder());
+        File file = new File(arenasFolder, worldName);
         if (!file.isDirectory()) {
             String resource = "MissileWars-Arena.zip";
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/SetupUtil.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/SetupUtil.java
@@ -108,7 +108,7 @@ public class SetupUtil {
     }
 
     public static void checkMap(String worldName) {
-        File file = new File(Config.getArenaFolder() + "/" + worldName);
+        File file = new File(Config.getArenasFolder() + worldName);
         if (!file.isDirectory()) {
             String resource = "MissileWars-Arena.zip";
 
@@ -125,7 +125,7 @@ public class SetupUtil {
     }
 
     public static void checkMissiles() {
-        File file = new File(MissileWars.getInstance().getDataFolder(), "missiles");
+        File file = new File(Config.getMissilesFolder());
         if (!file.isDirectory()) {
             String resource = "missiles.zip";
 


### PR DESCRIPTION
- Refactoring
- [Adding unified config for the definition of folders](https://github.com/Butzlabben/missilewars/commit/7fcdfa91690e2e7551bdb67d65432465ceb05c3c)
---

**Example:**
```
arenas:
  folder: plugins/MissileWars/X-arenas
lobbies:
  multiple_lobbies: false
  folder: plugins/MissileWars/X-lobbies
  default_lobby: lobby0.yml
missiles:
  folder: plugins/MissileWars/X-missiles
```
![grafik](https://user-images.githubusercontent.com/4140635/215912838-82810bcd-e577-4c73-a485-0bbfd65374a1.png)
