### PR TITLE
Hot-Fix dependency version of jackson-core

### DIFF
--- a/missilewars-plugin/pom.xml
+++ b/missilewars-plugin/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.12.4</version>
+            <version>2.14.2</version>
             <scope>compile</scope>
         </dependency>
 


### PR DESCRIPTION
Fixing new startup error https://pastebin.com/V7TJbaQA because of dependency change (POM) in #76 .