### PR TITLE
Refactoring Games.java : Adding EquipmentManager

### DIFF
--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/EquipmentManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/EquipmentManager.java
@@ -36,10 +36,10 @@ public class EquipmentManager {
 
     private final Game game;
 
+    private final MissileGameEquipment missileEquipment;
+    private final SpecialGameEquipment specialEquipment;
     private ItemStack customBow;
     private ItemStack customPickaxe;
-    private MissileGameEquipment missileEquipment;
-    private SpecialGameEquipment specialEquipment;
 
     
     public EquipmentManager(Game game) {

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/EquipmentManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/EquipmentManager.java
@@ -20,6 +20,11 @@ package de.butzlabben.missilewars.game.equipment;
 
 import de.butzlabben.missilewars.game.Game;
 import lombok.Getter;
+import org.bukkit.Material;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
 
 /**
  * @author Butzlabben
@@ -31,8 +36,82 @@ public class EquipmentManager {
 
     private final Game game;
 
+    private ItemStack customBow;
+    private ItemStack customPickaxe;
+    private MissileGameEquipment missileEquipment;
+    private SpecialGameEquipment specialEquipment;
+
     
     public EquipmentManager(Game game) {
         this.game = game;
+
+        missileEquipment = new MissileGameEquipment(game);
+        specialEquipment = new SpecialGameEquipment(game);
+    }
+
+    /**
+     * This method is used to create the game items for the player kit.
+     */
+    public void createGameItems() {
+
+        // Will it be used ?
+        if (game.getArena().getSpawn().isSendBow() || game.getArena().getRespawn().isSendBow()) {
+
+            ItemStack bow = new ItemStack(Material.BOW);
+            bow.addEnchantment(Enchantment.ARROW_FIRE, 1);
+            bow.addEnchantment(Enchantment.ARROW_DAMAGE, 1);
+            bow.addEnchantment(Enchantment.ARROW_KNOCKBACK, 1);
+            ItemMeta bowMeta = bow.getItemMeta();
+            bowMeta.setUnbreakable(true);
+            bowMeta.addEnchant(Enchantment.DAMAGE_ALL, 6, true);
+            bow.setItemMeta(bowMeta);
+            this.customBow = bow;
+        }
+
+        // Will it be used ?
+        if (game.getArena().getSpawn().isSendPickaxe() || game.getArena().getRespawn().isSendPickaxe()) {
+
+            ItemStack pickaxe = new ItemStack(Material.IRON_PICKAXE);
+            ItemMeta pickaxeMeta = pickaxe.getItemMeta();
+            pickaxeMeta.setUnbreakable(true);
+            pickaxe.setItemMeta(pickaxeMeta);
+            this.customPickaxe = pickaxe;
+        }
+
+    }
+
+    /**
+     * This method gives the player the starter item set, based on the config.yml
+     * configuration for spawn and respawn.
+     *
+     * @param player the target player
+     * @param isRespawn true, if the player should receive it after a respawn
+     */
+    public void sendGameItems(Player player, boolean isRespawn) {
+
+        if (isRespawn) {
+            if (game.getArena().isKeepInventory()) return;
+
+        } else {
+            // clear inventory
+            player.getInventory().clear();
+        }
+
+        // send armor
+        ItemStack[] armor = game.getPlayer(player).getTeam().getTeamArmor();
+        player.getInventory().setArmorContents(armor);
+
+        // send kit items
+        if (isRespawn) {
+
+            if (game.getArena().getRespawn().isSendBow()) player.getInventory().addItem(this.customBow);
+            if (game.getArena().getRespawn().isSendPickaxe()) player.getInventory().addItem(this.customPickaxe);
+
+        } else {
+
+            if (game.getArena().getSpawn().isSendBow()) player.getInventory().addItem(this.customBow);
+            if (game.getArena().getSpawn().isSendPickaxe()) player.getInventory().addItem(this.customPickaxe);
+
+        }
     }
 }

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/EquipmentManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/EquipmentManager.java
@@ -1,0 +1,38 @@
+/*
+ * This file is part of MissileWars (https://github.com/Butzlabben/missilewars).
+ * Copyright (c) 2018-2021 Daniel Nägele.
+ *
+ * MissileWars is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MissileWars is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MissileWars.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.butzlabben.missilewars.game.equipment;
+
+import de.butzlabben.missilewars.game.Game;
+import lombok.Getter;
+
+/**
+ * @author Butzlabben
+ * @since 19.01.2018
+ */
+
+@Getter
+public class EquipmentManager {
+
+    private final Game game;
+
+    
+    public EquipmentManager(Game game) {
+        this.game = game;
+    }
+}

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/PlayerEquipmentRandomizer.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/PlayerEquipmentRandomizer.java
@@ -37,6 +37,7 @@ public class PlayerEquipmentRandomizer {
     private final MWPlayer mwPlayer;
     private final Game game;
     private final Arena arena;
+    private final EquipmentManager equipmentManager;
 
     private final int maxGameDuration;
     private final Random randomizer;
@@ -51,6 +52,7 @@ public class PlayerEquipmentRandomizer {
         this.mwPlayer = mwPlayer;
         this.game = game;
         this.arena = game.getArena();
+        this.equipmentManager = game.getEquipmentManager();
         randomizer = new Random();
         maxGameDuration = game.getArena().getGameDuration() * 60;
 
@@ -112,15 +114,15 @@ public class PlayerEquipmentRandomizer {
         // after 2 missile items, you get one special item
         if (sendEquipmentCounter >= 2) {
 
-            randomID = randomizer.nextInt(game.getSpecialEquipment().getSpecialEquipmentList().size());
-            item = game.getSpecialEquipment().getSpecialEquipmentList().get(randomID);
+            randomID = randomizer.nextInt(equipmentManager.getSpecialEquipment().getSpecialEquipmentList().size());
+            item = equipmentManager.getSpecialEquipment().getSpecialEquipmentList().get(randomID);
 
             sendEquipmentCounter = 0;
 
         } else {
 
-            randomID = randomizer.nextInt(game.getMissileEquipment().getMissileEquipmentList().size());
-            Missile missile = game.getMissileEquipment().getMissileEquipmentList().get(randomID);
+            randomID = randomizer.nextInt(equipmentManager.getMissileEquipment().getMissileEquipmentList().size());
+            Missile missile = equipmentManager.getMissileEquipment().getMissileEquipmentList().get(randomID);
             item = missile.getItem();
 
         }

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/GameListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/GameListener.java
@@ -183,7 +183,7 @@ public class GameListener extends GameBoundListener {
 
         if (team != null) {
             event.setRespawnLocation(team.getSpawn());
-            getGame().sendGameItems(player, true);
+            getGame().getEquipmentManager().sendGameItems(player, true);
             getGame().setPlayerAttributes(player);
             getGame().getPlayer(player).getRandomGameEquipment().resetPlayerInterval();
 


### PR DESCRIPTION
The class `Games.java` is the central object for a game. However, some methods and fields can be outsourced to manager classes to keep the Games class a bit more manageable. The following is a suggestion for outsourcing:

**Games.java**
- NEW: _method_ EquipmentManager()

**Moving from `Game.java` to `EquipmentManager.java`**
- _field_ ItemStack customBow (+ Getter)
- _field_ ItemStack customPickaxe (+ Getter)
- _field_ MissileGameEquipment missileEquipment (+ Getter)
- _field_ SpecialGameEquipment specialEquipment (+ Getter)
- _method_ createGameItems()
- _method_ sendGameItems()