### PR TITLE
Adding TaskManager, Fixing player-data reset & scoreboard issue

### DIFF
--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
@@ -440,8 +440,10 @@ public class Game {
     }
 
     public void resetGame() {
+        // Teleporting players; the event listener will handle the teleport event
         applyForAllPlayers(this::teleportToAfterGameSpawn);
         
+        // Deactivation of all event handlers
         HandlerList.unregisterAll(listener);
         taskManager.stopTimer();
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
@@ -143,7 +143,7 @@ public class Game {
         taskManager.stopTimer();
         updateGameListener(new LobbyListener(this));
         taskManager.setTimer(new LobbyTimer(this, lobby.getLobbyTime()));
-        taskManager.setBukkitTask(0, 20);
+        taskManager.runTimer(0, 20);
         state = GameState.LOBBY;
 
         Bukkit.getScheduler().runTaskLater(MissileWars.getInstance(), () -> applyForAllPlayers(this::runTeleportEventForPlayer), 2);
@@ -218,7 +218,7 @@ public class Game {
         taskManager.stopTimer();
         updateGameListener(new GameListener(this));
         taskManager.setTimer(new GameTimer(this));
-        taskManager.setBukkitTask(5, 20);
+        taskManager.runTimer(5, 20);
         state = GameState.INGAME;
 
         timestart = System.currentTimeMillis();
@@ -254,7 +254,7 @@ public class Game {
         taskManager.stopTimer();
         updateGameListener(new EndListener(this));
         taskManager.setTimer(new EndTimer(this));
-        taskManager.setBukkitTask(5, 20);
+        taskManager.runTimer(5, 20);
         state = GameState.END;
 
         updateMOTD();

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/Game.java
@@ -98,6 +98,7 @@ public class Game {
     private GameBoundListener listener;
     private EquipmentManager equipmentManager;
     private TaskManager taskManager;
+    private int remainingGameDuration;
 
     public Game(Lobby lobby) {
         Logger.BOOT.log("Loading lobby " + lobby.getName());
@@ -246,7 +247,10 @@ public class Game {
             teleportToArenaSpectatorSpawn(player);
 
         }
-
+        
+        // Save the remaining game duration.
+        remainingGameDuration = taskManager.getTimer().getSeconds();
+        
         taskManager.stopTimer();
         updateGameListener(new EndListener(this));
         taskManager.setTimer(new EndTimer(this));
@@ -436,14 +440,12 @@ public class Game {
     }
 
     public void resetGame() {
-        HandlerList.unregisterAll(listener);
-
-        taskManager = new TaskManager(this);
-
         applyForAllPlayers(this::teleportToAfterGameSpawn);
+        
+        HandlerList.unregisterAll(listener);
+        taskManager.stopTimer();
 
         if (gameWorld != null) {
-            gameWorld.sendPlayersBack();
             gameWorld.unload();
             gameWorld.delete();
         }

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/PlayerEquipmentRandomizer.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/PlayerEquipmentRandomizer.java
@@ -172,7 +172,7 @@ public class PlayerEquipmentRandomizer {
             return DEFAULT_FACTOR_BY_GAME_TIME;
         }
 
-        int seconds = game.getTimer().getSeconds();
+        int seconds = game.getTaskManager().getTimer().getSeconds();
         for (int i = seconds; i <= maxGameDuration; i++) {
             if (arena.getInterval().getIntervalFactorByGameTime().containsKey(Integer.toString(i))) {
                 return arena.getInterval().getIntervalFactorByGameTime().get(Integer.toString(i));

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/ScoreboardManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/ScoreboardManager.java
@@ -228,11 +228,15 @@ public class ScoreboardManager {
      */
     private String replaceScoreboardPlaceholders(String text) {
 
-        String time;
+        String time = "";
         if (game.getState() == GameState.LOBBY) {
+            // Show the planned duration of the next game:
             time = Integer.toString(game.getArena().getGameDuration());
-        } else {
-            time = Integer.toString(game.getTimer().getSeconds() / 60);
+        } else if (game.getState() == GameState.INGAME) {
+            // Show the remaining duration of the running game:
+            time = Integer.toString(game.getTaskManager().getTimer().getSeconds() / 60);
+        } else if (game.getState() == GameState.END) {
+            time = Integer.toString(game.getRemainingGameDuration() / 60);
         }
 
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/ScoreboardManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/ScoreboardManager.java
@@ -236,6 +236,7 @@ public class ScoreboardManager {
             // Show the remaining duration of the running game:
             time = Integer.toString(game.getTaskManager().getTimer().getSeconds() / 60);
         } else if (game.getState() == GameState.END) {
+            // Show the remaining duration of the last game:
             time = Integer.toString(game.getRemainingGameDuration() / 60);
         }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/timer/TaskManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/timer/TaskManager.java
@@ -1,0 +1,54 @@
+/*
+ * This file is part of MissileWars (https://github.com/Butzlabben/missilewars).
+ * Copyright (c) 2018-2021 Daniel Nägele.
+ *
+ * MissileWars is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * MissileWars is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with MissileWars.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package de.butzlabben.missilewars.game.timer;
+
+import de.butzlabben.missilewars.MissileWars;
+import de.butzlabben.missilewars.game.Game;
+import lombok.Getter;
+import lombok.Setter;
+import org.bukkit.Bukkit;
+import org.bukkit.scheduler.BukkitTask;
+
+/**
+ * @author Butzlabben
+ * @since 14.01.2018
+ */
+
+@Getter
+public class TaskManager {
+
+    private final Game game;
+
+    @Setter private Timer timer;
+    private BukkitTask bukkitTask;
+
+    public TaskManager(Game game) {
+        this.game = game;
+    }
+    
+    public void setBukkitTask(long delay, long period) {
+        bukkitTask = Bukkit.getScheduler().runTaskTimer(MissileWars.getInstance(), timer , delay, period);
+    }
+
+    public void stopTimer() {
+        if (bukkitTask != null)
+            bukkitTask.cancel();
+    }
+    
+}

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/timer/TaskManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/timer/TaskManager.java
@@ -42,7 +42,7 @@ public class TaskManager {
         this.game = game;
     }
     
-    public void setBukkitTask(long delay, long period) {
+    public void runTimer(long delay, long period) {
         bukkitTask = Bukkit.getScheduler().runTaskTimer(MissileWars.getInstance(), timer , delay, period);
     }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/LobbyListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/LobbyListener.java
@@ -69,7 +69,7 @@ public class LobbyListener extends GameBoundListener {
             if (displayName.equals(getGame().getPlayer(player).getTeam().getFullname())) return;
 
             // too late for team change:
-            if (getGame().getTimer().getSeconds() < 10) {
+            if (getGame().getTaskManager().getTimer().getSeconds() < 10) {
                 player.sendMessage(Messages.getMessage(true, Messages.MessageEnum.TEAM_CHANGE_TEAM_NO_LONGER_NOW));
                 return;
             }


### PR DESCRIPTION
The class `Games.java` is the central object for a game. However, some methods and fields can be outsourced to manager classes to keep the Games class a bit more manageable. The following is a suggestion for outsourcing:

**Games.java**
- NEW: _method_ TaskManager()

**Moving from `Game.java` to `TaskManager.java`**
- _field_ Timer timer (+ Getter)
- _field_ BukkitTask bt (+ Getter)

---

With this investigation, a runtime issue was also found and fixed that did not correctly reset the player datas after the `GameState.END` phase, because the EventListeners were already disabled. In addition, the game duration (currently for the scoreboard) was cached for the `GameState.END` phase.