### PR TITLE
Cancelling inventory opening

### DIFF
--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/EndListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/EndListener.java
@@ -29,6 +29,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 
 /**
@@ -56,6 +57,14 @@ public class EndListener extends GameBoundListener {
 
         event.setDeathMessage(null);
         if (getGame().getArena().isAutoRespawn()) getGame().autoRespawnPlayer(player);
+    }
+
+    @EventHandler
+    public void onInventoryOpen(InventoryOpenEvent event) {
+        Player player = (Player) event.getPlayer();
+        if (!isInGameWorld(player.getLocation())) return;
+
+        if (player.getGameMode() != GameMode.CREATIVE) event.setCancelled(true);
     }
 
     @EventHandler

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/GameListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/GameListener.java
@@ -239,6 +239,10 @@ public class GameListener extends GameBoundListener {
 
     @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
+
+        // Putting the items inside is not perfectly locked. But it is a second protection.
+        // More checks are possible: https://www.spigotmc.org/threads/531737
+
         if (!(event.getWhoClicked() instanceof Player)) return;
 
         Player player = (Player) event.getWhoClicked();

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/GameListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/GameListener.java
@@ -41,12 +41,9 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPhysicsEvent;
-import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.entity.EntityExplodeEvent;
-import org.bukkit.event.entity.PlayerDeathEvent;
-import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.event.entity.*;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
@@ -229,6 +226,18 @@ public class GameListener extends GameBoundListener {
     }
 
     @EventHandler
+    public void onInventoryOpen(InventoryOpenEvent event) {
+        Player player = (Player) event.getPlayer();
+        if (!isInGameWorld(player.getLocation())) return;
+
+        if (player.getGameMode() == GameMode.CREATIVE) return;
+        if (player.getGameMode() == GameMode.SPECTATOR) event.setCancelled(true);
+
+        Inventory clickedInventory = event.getInventory();
+        if (clickedInventory.getType() != InventoryType.PLAYER) event.setCancelled(true);
+    }
+
+    @EventHandler
     public void onInventoryClick(InventoryClickEvent event) {
         if (!(event.getWhoClicked() instanceof Player)) return;
 
@@ -236,7 +245,6 @@ public class GameListener extends GameBoundListener {
         if (!isInGameWorld(player.getLocation())) return;
 
         if (player.getGameMode() == GameMode.CREATIVE) return;
-
         if (player.getGameMode() == GameMode.SPECTATOR) event.setCancelled(true);
 
         Inventory clickedInventory = event.getClickedInventory();

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/LobbyListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/LobbyListener.java
@@ -101,6 +101,9 @@ public class LobbyListener extends GameBoundListener {
     public void onInventoryOpen(InventoryOpenEvent event) {
         Player player = (Player) event.getPlayer();
         if (!isInLobbyArea(player.getLocation())) return;
+        
+        // handling of vote inventory:
+        if (event.getView().getTitle().equals(Messages.getMessage(false, Messages.MessageEnum.VOTE_GUI))) return;
 
         if (player.getGameMode() != GameMode.CREATIVE) event.setCancelled(true);
     }
@@ -112,6 +115,8 @@ public class LobbyListener extends GameBoundListener {
         Player player = (Player) event.getWhoClicked();
         if (!isInLobbyArea(player.getLocation())) return;
 
+        // handling of vote inventory: see 'VoteInventory.class'
+        
         if (player.getGameMode() != GameMode.CREATIVE) event.setCancelled(true);
     }
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/LobbyListener.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/listener/game/LobbyListener.java
@@ -31,6 +31,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 
@@ -94,6 +95,14 @@ public class LobbyListener extends GameBoundListener {
         if (!isInLobbyArea(event.getPlayer().getLocation())) return;
 
         event.setRespawnLocation(getGame().getLobby().getSpawnPoint());
+    }
+
+    @EventHandler
+    public void onInventoryOpen(InventoryOpenEvent event) {
+        Player player = (Player) event.getPlayer();
+        if (!isInLobbyArea(player.getLocation())) return;
+
+        if (player.getGameMode() != GameMode.CREATIVE) event.setCancelled(true);
     }
 
     @EventHandler


### PR DESCRIPTION
Currently, only the removal from other inventories is properly prevented. Putting it inside is partially possible. With this, I prevent the opening of inventory blocks completely.