### PR TITLE
Using '&' color codes as default in the sidebar configuration

### DIFF
--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/Config.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/Config.java
@@ -122,12 +122,12 @@ public class Config {
         if (isNewConfig) {
             List<String> sidebarList = new ArrayList<>();
 
-            sidebarList.add("§7Time left:");
-            sidebarList.add("§e» %time%m");
+            sidebarList.add("&7Time left:");
+            sidebarList.add("&e» %time%m");
             sidebarList.add("");
-            sidebarList.add("%team1% §7» %team1_color%%team1_amount%");
+            sidebarList.add("%team1% &7» %team1_color%%team1_amount%");
             sidebarList.add("");
-            sidebarList.add("%team2% §7» %team2_color%%team2_amount%");
+            sidebarList.add("%team2% &7» %team2_color%%team2_amount%");
 
             cfg.set("sidebar.entries", sidebarList);
         }


### PR DESCRIPTION
Changing the default color codes to "&", because he will anyway translated in "§" color codes [here](https://github.com/RedstoneFuture/missilewars/blob/c126b76eae4b0ae4c196197c81a04693394f04ea/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/misc/ScoreboardManager.java#L260).