### PR TITLE
Adding new options for game-join and respawn equipment interval

### DIFF
--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/arena/EquipmentIntervalConfiguration.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/arena/EquipmentIntervalConfiguration.java
@@ -30,7 +30,9 @@ import lombok.ToString;
 @RequiredArgsConstructor
 public class EquipmentIntervalConfiguration {
 
-    private int start = 10;
+    @SerializedName("custom_start_interval") private int customStartInterval = 10;
+    @SerializedName("reset_after_respawn") private boolean resetAfterRespawn = true;
+    @SerializedName("custom_respawn_interval") private int customRespawnInterval = 10;
 
     @SerializedName("intervals_by_team_amount") private Map<String, Integer> intervalsByTeamAmount = new HashMap<>() {{
         put("1", 15);


### PR DESCRIPTION
Fixing #102 

- Adding new config options in the **arena config**
  - "start" option is now "custom_start_interval"; and now it's only for the game join (`-1` if you wish to use the basic interval based on the team amount and the game time)
  - if "reset_after_respawn" is `true` the interval is resetting with death respawn
  - "custom_respawn_interval" is now only for the respawn interval (`-1` if you wish to use the basic interval based on the team amount and the game time)

**previous version:**

```
equipment_interval:
  start: 10
  intervals_by_team_amount:
    "1": 15
    "2": 20
    "4": 25
  interval_factor_by_game_time:
    "1800": 1.0
    "300": 0.7
    "600": 0.8
    "900": 0.9
```

**now:**

```
equipment_interval:
  custom_start_interval: 10
  reset_after_respawn: true
  custom_respawn_interval: 10
  intervals_by_team_amount:
    "1": 15
    "2": 20
    "4": 25
  interval_factor_by_game_time:
    "1800": 1.0
    "300": 0.7
    "600": 0.8
    "900": 0.9
```