### PR TITLE
Adding support for MC 1.21.1

### DIFF
--- a/FAWE_Paster/pom.xml
+++ b/FAWE_Paster/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>com.fastasyncworldedit</groupId>
             <artifactId>FastAsyncWorldEdit-Core</artifactId>
-            <version>2.11.0</version>
+            <version>2.12.2</version>
             <scope>provided</scope>
         </dependency>
 

--- a/missilewars-plugin/pom.xml
+++ b/missilewars-plugin/pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.16.1</version>
+            <version>2.18.0</version>
         </dependency>
 
         <!-- https://github.com/aikar/commands -->
@@ -73,20 +73,20 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.16.2</version>
+            <version>2.17.2</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml -->
         <dependency>
             <groupId>com.fasterxml.jackson.dataformat</groupId>
             <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>2.16.2</version>
+            <version>2.17.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>3.0.2</version>
+            <version>3.1.0</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/com.github.MilkBowl/VaultAPI -->
@@ -109,7 +109,7 @@
         <dependency>
             <groupId>com.github.placeholderapi</groupId>
             <artifactId>placeholderapi</artifactId>
-            <version>2.11.5</version>
+            <version>2.11.6</version>
             <scope>provided</scope>
         </dependency>
 
@@ -123,7 +123,7 @@
         <dependency>
             <groupId>com.github.stefvanschie.inventoryframework</groupId>
             <artifactId>IF</artifactId>
-            <version>0.10.15</version>
+            <version>0.10.19</version>
         </dependency>
     </dependencies>
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/arena/modules/MissileConfig.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/configuration/arena/modules/MissileConfig.java
@@ -49,7 +49,7 @@ public class MissileConfig extends SchematicConfiguration {
         add(new Missile("Tomahawk.schem", "&a%schematic_name_compact%", 3, EntityType.CREEPER, 0, 2));
         add(new Missile("Cruiser.schem", "&e%schematic_name_compact%", 2, EntityType.BLAZE, 0, 2));
         add(new Missile("Sword.schem", "&7%schematic_name_compact%", 2, EntityType.SKELETON, 0, 2));
-        add(new Missile("Juggernaut.schem", "&4%schematic_name_compact%", 2, EntityType.MUSHROOM_COW, 0, 2));
+        add(new Missile("Juggernaut.schem", "&4%schematic_name_compact%", 2, EntityType.MOOSHROOM, 0, 2));
         add(new Missile("Piranha.schem", "&3%schematic_name_compact%", 3, EntityType.HORSE, 0, 2));
         add(new Missile("Tunnelbore.schem", "&0%schematic_name_compact%", 1, EntityType.ENDERMAN, 0, 2));
     }};

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/EquipmentManager.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/equipment/EquipmentManager.java
@@ -61,12 +61,12 @@ public class EquipmentManager {
         if (game.getArenaConfig().getSpawn().isSendBow() || game.getArenaConfig().getRespawn().isSendBow()) {
 
             ItemStack bow = new ItemStack(Material.BOW);
-            bow.addEnchantment(Enchantment.ARROW_FIRE, 1);
-            bow.addEnchantment(Enchantment.ARROW_DAMAGE, 1);
-            bow.addEnchantment(Enchantment.ARROW_KNOCKBACK, 1);
+            bow.addEnchantment(Enchantment.FLAME, 1);
+            bow.addEnchantment(Enchantment.POWER, 1);
+            bow.addEnchantment(Enchantment.PUNCH, 1);
             ItemMeta bowMeta = bow.getItemMeta();
             bowMeta.setUnbreakable(true);
-            bowMeta.addEnchant(Enchantment.DAMAGE_ALL, 6, true);
+            bowMeta.addEnchant(Enchantment.SHARPNESS, 6, true);
             bow.setItemMeta(bowMeta);
             this.customBow = bow;
         }

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/schematics/objects/Missile.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/game/schematics/objects/Missile.java
@@ -118,7 +118,7 @@ public class Missile extends SchematicObject {
     }
 
     public static Material getSpawnEgg(EntityType type) {
-        if (type == EntityType.MUSHROOM_COW) {
+        if (type == EntityType.MOOSHROOM) {
             return Material.valueOf("MOOSHROOM_SPAWN_EGG");
 
         }

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/menus/MenuItem.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/menus/MenuItem.java
@@ -122,7 +122,7 @@ public class MenuItem {
     
     public static void setEnchantment(ItemStack itemStack) {
         ItemMeta itemMeta = itemStack.getItemMeta();
-        if (itemMeta != null) itemMeta.addEnchant(Enchantment.LUCK, 10, true);
+        if (itemMeta != null) itemMeta.addEnchant(Enchantment.FORTUNE, 10, true);
         itemStack.setItemMeta(itemMeta);
     }
     
@@ -135,7 +135,7 @@ public class MenuItem {
     public static void hideMetaValues(ItemStack itemStack) {
         ItemMeta itemMeta = itemStack.getItemMeta();
         if (itemMeta != null) itemMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES, ItemFlag.HIDE_DESTROYS, ItemFlag.HIDE_DYE, ItemFlag.HIDE_ENCHANTS, 
-                ItemFlag.HIDE_PLACED_ON, ItemFlag.HIDE_UNBREAKABLE, ItemFlag.HIDE_POTION_EFFECTS);
+                ItemFlag.HIDE_PLACED_ON, ItemFlag.HIDE_UNBREAKABLE, ItemFlag.HIDE_ARMOR_TRIM, ItemFlag.HIDE_ADDITIONAL_TOOLTIP);
         itemStack.setItemMeta(itemMeta);
     }
     

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/menus/MenuItem.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/menus/MenuItem.java
@@ -1,11 +1,9 @@
 package de.butzlabben.missilewars.menus;
 
-import com.mojang.authlib.GameProfile;
-import com.mojang.authlib.properties.Property;
-import de.butzlabben.missilewars.Logger;
 import de.butzlabben.missilewars.configuration.ActionSet;
 import de.butzlabben.missilewars.configuration.PluginMessages;
 import de.butzlabben.missilewars.player.MWPlayer;
+import de.redstoneworld.redutilities.items.HeadHelper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
@@ -16,13 +14,9 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
-import org.bukkit.inventory.meta.SkullMeta;
 
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 public class MenuItem {
@@ -52,7 +46,7 @@ public class MenuItem {
         
         // basehead-<base64 (Value field in the head's give command)>
         if (materialName.startsWith("basehead-")) {
-            tempItem = getCustomHead(materialName.split("-")[1]);
+            tempItem = HeadHelper.getCustomHead(materialName.split("-")[1]);
             
         } else if (materialName.equalsIgnoreCase("{player-team-item}")) {
             tempItem = mwPlayer.getTeam().getMenuItem();
@@ -78,37 +72,6 @@ public class MenuItem {
     public void sendToPlayer(MWPlayer mwPlayer) {
         updateItem(mwPlayer);
         mwPlayer.getPlayer().getInventory().setItem(slot, itemStack);
-    }
-    
-    public static ItemStack getCustomHead(String base64Texture) {
-        ItemStack headItem = new ItemStack(Material.PLAYER_HEAD);
-        SkullMeta skullMeta = (SkullMeta) headItem.getItemMeta();
-        setSkinViaBase64(skullMeta, base64Texture);
-        headItem.setItemMeta(skullMeta);
-        return headItem;
-    }
-
-    /**
-     * A method used to set the skin of a player skull via a base64 encoded string.
-     *
-     * Source: <a href="https://www.spigotmc.org/threads/generated-texture-to-heads.512604/#post-4198463">Post by BoBoBalloon</a>
-     *
-     * @param meta the skull meta to modify
-     * @param base64 the base64 encoded string
-     */
-    private static void setSkinViaBase64(SkullMeta meta, String base64) {
-        try {
-            Method setProfile = meta.getClass().getDeclaredMethod("setProfile", GameProfile.class);
-            setProfile.setAccessible(true);
-
-            GameProfile profile = new GameProfile(UUID.randomUUID(), "skull-texture");
-            profile.getProperties().put("textures", new Property("textures", base64));
-
-            setProfile.invoke(meta, profile);
-        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            Logger.ERROR.log("There was a severe internal reflection error when attempting to set the skin of a player skull via base64!");
-            e.printStackTrace();
-        }
     }
     
     private void updatePapiValues(Player player) {

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/menus/inventory/MapVoteMenu.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/menus/inventory/MapVoteMenu.java
@@ -11,6 +11,7 @@ import de.butzlabben.missilewars.game.Game;
 import de.butzlabben.missilewars.menus.MenuItem;
 import de.butzlabben.missilewars.menus.MenuUtils;
 import de.butzlabben.missilewars.player.MWPlayer;
+import de.redstoneworld.redutilities.items.HeadHelper;
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
@@ -33,10 +34,10 @@ public class MapVoteMenu {
     GuiItem backwardsItem;
     GuiItem forwardsItem;
     
-    final ItemStack backwardsItemActive = MenuItem.getCustomHead("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDliMmJlZTM5YjZlZjQ3ZTE4MmQ2ZjFkY2E5ZGVhODQyZmNkNjhiZGE5YmFjYzZhNmQ2NmE4ZGNkZjNlYyJ9fX0=");
-    final ItemStack backwardsItemInactive = MenuItem.getCustomHead("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTQyZmRlOGI4MmU4YzFiOGMyMmIyMjY3OTk4M2ZlMzVjYjc2YTc5Nzc4NDI5YmRhZGFiYzM5N2ZkMTUwNjEifX19");
-    final ItemStack forwardsItemActive = MenuItem.getCustomHead("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTQxZmY2YmM2N2E0ODEyMzJkMmU2NjllNDNjNGYwODdmOWQyMzA2NjY1YjRmODI5ZmI4Njg5MmQxM2I3MGNhIn19fQ==");
-    final ItemStack forwardsItemInactive = MenuItem.getCustomHead("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDA2MjYyYWYxZDVmNDE0YzU5NzA1NWMyMmUzOWNjZTE0OGU1ZWRiZWM0NTU1OWEyZDZiODhjOGQ2N2I5MmVhNiJ9fX0=");
+    final ItemStack backwardsItemActive = HeadHelper.getCustomHead("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDliMmJlZTM5YjZlZjQ3ZTE4MmQ2ZjFkY2E5ZGVhODQyZmNkNjhiZGE5YmFjYzZhNmQ2NmE4ZGNkZjNlYyJ9fX0=");
+    final ItemStack backwardsItemInactive = HeadHelper.getCustomHead("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTQyZmRlOGI4MmU4YzFiOGMyMmIyMjY3OTk4M2ZlMzVjYjc2YTc5Nzc4NDI5YmRhZGFiYzM5N2ZkMTUwNjEifX19");
+    final ItemStack forwardsItemActive = HeadHelper.getCustomHead("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMTQxZmY2YmM2N2E0ODEyMzJkMmU2NjllNDNjNGYwODdmOWQyMzA2NjY1YjRmODI5ZmI4Njg5MmQxM2I3MGNhIn19fQ==");
+    final ItemStack forwardsItemInactive = HeadHelper.getCustomHead("eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNDA2MjYyYWYxZDVmNDE0YzU5NzA1NWMyMmUzOWNjZTE0OGU1ZWRiZWM0NTU1OWEyZDZiODhjOGQ2N2I5MmVhNiJ9fX0=");
     
     public MapVoteMenu(MWPlayer mwPlayer) {
         this.mwPlayer = mwPlayer;

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <dependency>
             <groupId>de.redstoneworld.redutilities</groupId>
             <artifactId>redutilities</artifactId>
-            <version>0.0.17-Snapshot</version>
+            <version>0.0.18-Snapshot</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.20.4-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
 
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-bukkit</artifactId>
-            <version>7.3.0</version>
+            <version>7.3.9</version>
             <scope>provided</scope>
 
             <exclusions>
@@ -87,7 +87,7 @@
         <dependency>
             <groupId>com.sk89q.worldedit</groupId>
             <artifactId>worldedit-core</artifactId>
-            <version>7.3.0</version>
+            <version>7.3.9</version>
             <scope>provided</scope>
         </dependency>
 
@@ -95,14 +95,14 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.34</version>
+            <version>1.18.36</version>
             <scope>provided</scope>
         </dependency>
         
         <dependency>
             <groupId>de.redstoneworld.redutilities</groupId>
             <artifactId>redutilities</artifactId>
-            <version>0.0.14-Snapshot</version>
+            <version>0.0.17-Snapshot</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,8 +126,8 @@
                 <version>3.5.1</version>
                 <configuration>
                     <forceJavacCompilerUse>true</forceJavacCompilerUse>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
# Overview
- Dependency updates
  - SpigotMC `1.20.4` -> `1.21.1`
- Updating Java version for the plugin buildung (`11` -> `17`)
- Updating enum values of `EntityType`, `Enchantment`, `ItemFlag` (no behavior changes)
- Replacing method to get player heads with custom texture (Base64)

> **Note:** As of 1.21.3 there is a problem with another dependency. This will be fixed in the next PR.

# Wiki-Update
- [x] Changing supported version to "1.21.1"

# Participants
Thank you @alexsvorada and @gamecrash534 for your Pull-Requests with the suggestions for changes! These have been taken into account here.