### PR TITLE
Dependency Updates

### DIFF
--- a/missilewars-plugin/pom.xml
+++ b/missilewars-plugin/pom.xml
@@ -115,7 +115,7 @@
         <dependency>
             <groupId>com.github.stefvanschie.inventoryframework</groupId>
             <artifactId>IF</artifactId>
-            <version>0.11.2</version>
+            <version>0.11.6</version>
         </dependency>
     </dependencies>
 

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/menus/inventory/MapVoteMenu.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/menus/inventory/MapVoteMenu.java
@@ -118,6 +118,8 @@ public class MapVoteMenu {
             
             
             arenas.setOnClick(event -> {
+                event.setCancelled(true);
+                
                 // prevent spam with the event handling
                 if (menuUtils.isInteractDelay(mwPlayer, event)) return;
                 menuUtils.setInteractDelay(mwPlayer.getPlayer());
@@ -130,11 +132,10 @@ public class MapVoteMenu {
             });
             
             backwards.setOnClick(event -> {
-                if (isFirstPage()) {
-                    event.setCancelled(true);
-                    return;
-                }
-
+                event.setCancelled(true);
+                
+                if (isFirstPage()) return;
+                
                 paginatedPane.setPage(paginatedPane.getPage() - 1);
                 backwardsItem.setItem(getBackwardsItem());
                 forwardsItem.setItem(getForwardsItem());
@@ -142,11 +143,10 @@ public class MapVoteMenu {
             });
             
             forwards.setOnClick(event -> {
-                if (isLastPage()) {
-                    event.setCancelled(true);
-                    return;
-                }
-
+                event.setCancelled(true);
+                
+                if (isLastPage()) return;
+                
                 paginatedPane.setPage(paginatedPane.getPage() + 1);
                 backwardsItem.setItem(getBackwardsItem());
                 forwardsItem.setItem(getForwardsItem());

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/menus/inventory/TeamSelectionMenu.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/menus/inventory/TeamSelectionMenu.java
@@ -76,6 +76,8 @@ public class TeamSelectionMenu {
         updateGuiItems(mwPlayer);
         
         pane1.setOnClick(event -> {
+            event.setCancelled(true);
+            
             // prevent spam with the event handling
             if (menuUtils.isInteractDelay(mwPlayer, event)) return;
             menuUtils.setInteractDelay(mwPlayer.getPlayer());
@@ -87,6 +89,8 @@ public class TeamSelectionMenu {
         });
         
         pane2.setOnClick(event -> {
+            event.setCancelled(true);
+            
             // prevent spam with the event handling
             if (menuUtils.isInteractDelay(mwPlayer, event)) return;
             menuUtils.setInteractDelay(mwPlayer.getPlayer());
@@ -98,6 +102,8 @@ public class TeamSelectionMenu {
         });
         
         paneSpec.setOnClick(event -> {
+            event.setCancelled(true);
+            
             // prevent spam with the event handling
             if (menuUtils.isInteractDelay(mwPlayer, event)) return;
             menuUtils.setInteractDelay(mwPlayer.getPlayer());

--- a/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/version/VersionUtil.java
+++ b/missilewars-plugin/src/main/java/de/butzlabben/missilewars/util/version/VersionUtil.java
@@ -38,8 +38,8 @@ public class VersionUtil {
             // Detect version:
             String v = Bukkit.getVersion();
 
-            if (v.startsWith("1.22")) {
-                version = 22;
+            if (v.startsWith("26")) {
+                version = 26;
             } else if (v.startsWith("1.21")) {
                 version = 21;
             } else if (v.startsWith("1.20")) {

--- a/missilewars-plugin/src/main/resources-filtered/plugin.yml
+++ b/missilewars-plugin/src/main/resources-filtered/plugin.yml
@@ -2,7 +2,7 @@ name: MissileWars
 authors: [Butzlabben, RedstoneFuture]
 version: ${project.version}
 main: de.butzlabben.missilewars.MissileWars
-api-version: 1.20
+api-version: 1.21
 depend: [ WorldEdit ]
 softdepend: [ FastAsyncWorldEdit, PlaceholderAPI ]
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <dependency>
             <groupId>de.redstoneworld.redutilities</groupId>
             <artifactId>redutilities</artifactId>
-            <version>0.0.18-Snapshot</version>
+            <version>0.0.20-Snapshot</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -39,8 +39,8 @@
 
     <repositories>
         <repository>
-            <id>spigot-repo</id>
-            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+            <id>papermc</id>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
 
         <repository>
@@ -66,10 +66,10 @@
     </repositories>
 
     <dependencies>
-        <!-- repo spigot-repo -->
+        <!-- repo paper-repo -->
         <dependency>
-            <groupId>org.spigotmc</groupId>
-            <artifactId>spigot-api</artifactId>
+            <groupId>io.papermc.paper</groupId>
+            <artifactId>paper-api</artifactId>
             <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>


### PR DESCRIPTION
# Overview
- Updating api-version in `plugin.yml` (1.21)
- Replacing SpigotMC dependency with PaperMC
- Updating dependencies (RedUtilities, IF)
  - Using of new method for custom Player-Head texture handling (MC >1.21.1) by RedUtilities and the PaperMC API
- Fixing interaction cancelling of menu items (for IF >0.11.3)
- Updating version check to support new version system by Mojang

# Wiki-Update
- [x] Infos about server-software support, version support and dependencies ([here](https://github.com/RedstoneFuture/missilewars/wiki/Home))